### PR TITLE
To avoid two web-socket instances running at once

### DIFF
--- a/web-socket.html
+++ b/web-socket.html
@@ -78,12 +78,6 @@ declarative element definition is:
       }
     },
 
-    attached: function () {
-      if (this.auto) {
-        this.open();
-      }
-    },
-
     detached: function () {
       this.close();
     },


### PR DESCRIPTION
I noticed when using this component with Polymer 1.6.1 that it always creates two active instances of WS when "auto" is applied. It seems to be instantiating one with the "attached" functionality, and another one with the _urlChanged observer. Since we are always applying a custom URL, it is always executed at run time which ends up with two active instances. I suggest removing the "attached" functionality since the "_urlChanged" will always fire anyway.
