### PR TITLE
Fix resetting _reopenInterval problem

### DIFF
--- a/web-socket.html
+++ b/web-socket.html
@@ -86,6 +86,12 @@ declarative element definition is:
       }
     },
 
+    ready: function() {
+      this._config = {
+        _reopenInterval: this._reopenInterval
+      };
+    },
+
     attached: function () {
       if (this.auto) {
         this.open();


### PR DESCRIPTION
In `_onOpen()` function, `this._config` is used for reverting
`_reopenInterval property`, but it was undefined.